### PR TITLE
Add module support to the list command

### DIFF
--- a/base.go
+++ b/base.go
@@ -17,10 +17,10 @@ type Command struct {
 	// The first word in the line is taken to be the command name.
 	UsageLine string
 
-	// Short is the short description shown in the 'gohack help' output.
+	// Short is the short description shown in the 'modcop help' output.
 	Short string
 
-	// Long is the long message shown in the 'gohack help <this-command>' output.
+	// Long is the long message shown in the 'modcop help <this-command>' output.
 	Long string
 
 	// Flag is a set of flags specific to this command.
@@ -33,5 +33,5 @@ func (c *Command) Name() string {
 
 func (c *Command) Usage() {
 	fmt.Fprintf(os.Stderr, "usage: %s\n", c.UsageLine)
-	fmt.Fprintf(os.Stderr, "Run 'gohack help %s' for details.\n", c.Name())
+	fmt.Fprintf(os.Stderr, "Run 'modcop help %s' for details.\n", c.Name())
 }

--- a/cmdlist.go
+++ b/cmdlist.go
@@ -1,24 +1,28 @@
 package main
 
 import (
+	"bufio"
 	"os"
-
-	"github.com/rogpeppe/modcop/depfile"
+	"sort"
+	"strings"
 )
 
 var listCommand = &Command{
 	Short:     "list dependencies",
 	UsageLine: "list [packages]",
 	Long: `
-List shows the set of current dependencies of the listed packages.
-By default, only build dependencies are listed; if the
--test flag is provided, test dependencies will be listed too.
+List shows the set of current dependencies of the listed packages,
+one per line. By default, only build dependencies are listed; if the
+-test flag is provided, test dependencies will be listed too;
+if the -testonly flag is provided, only dependencies that are
+used exclusively by tests will be listed.
 If the -m flag is provided, dependencies will be printed at the
 module level and version information will be printed too,
 in the same format used by "go list -m".
 
 List accepts the same package wildcard patterns that are accepted
-by the go list command.
+by the go list command. For more about specifying packages,
+see 'go help packages'.
 `[1:],
 }
 
@@ -27,30 +31,53 @@ func init() {
 }
 
 var (
-	listWithTest = listCommand.Flag.Bool("test", false, "show test dependencies too")
-	listModules  = listCommand.Flag.Bool("m", false, "show dependencies at module level")
+	listWithTest     = listCommand.Flag.Bool("test", false, "show test dependencies too")
+	listWithTestOnly = listCommand.Flag.Bool("testonly", false, "show test dependencies only")
+	listModules      = listCommand.Flag.Bool("m", false, "show dependencies at module level")
 )
 
 func cmdList(_ *Command, args []string) int {
 	if len(args) == 0 {
 		args = []string{"."}
 	}
-	build, test, err := deps(args, *listWithTest)
+	pkgs, pkgDeps, err := deps(args, *listWithTest || *listWithTestOnly)
 	if err != nil {
 		errorf("%v", err)
 		return 1
 	}
-	buildPkgs := make([]string, len(build))
-	for i, p := range build {
-		buildPkgs[i] = p.ImportPath
+	if *listModules {
+		mods := make(dependencyMap)
+		for ipName, testOnly := range pkgDeps {
+			p := pkgs[ipName]
+			if p.Module == nil && !p.Standard {
+				continue
+			}
+			var pattern string
+			switch {
+			case p.Standard && strings.Contains(ipName, "test"):
+				pattern = "stdtest"
+			case p.Standard:
+				pattern = "std"
+			default:
+				pattern = p.Module.Path + "/..."
+			}
+			mods.markVisited(pattern, testOnly)
+		}
+		pkgDeps = mods
 	}
-	testPkgs := make([]string, len(test))
-	for i, p := range test {
-		testPkgs[i] = p.ImportPath
+	listPkgs := make([]string, 0, len(pkgDeps))
+	for ipName, testOnly := range pkgDeps {
+		if *listWithTestOnly && !testOnly {
+			continue
+		}
+		listPkgs = append(listPkgs, ipName)
 	}
-	os.Stdout.Write(depfile.Format(&depfile.File{
-		Build: buildPkgs,
-		Test:  testPkgs,
-	}))
+	sort.Strings(listPkgs)
+	w := bufio.NewWriter(os.Stdout)
+	for _, p := range listPkgs {
+		w.WriteString(p)
+		w.WriteByte('\n')
+	}
+	w.Flush()
 	return 0
 }

--- a/help.go
+++ b/help.go
@@ -27,7 +27,7 @@ func runHelp(args []string) int {
 			return 0
 		}
 	}
-	fmt.Fprintf(os.Stderr, "gohack help %s: unknown command\n", args[0])
+	fmt.Fprintf(os.Stderr, "modcop help %s: unknown command\n", args[0])
 	return 2
 }
 
@@ -39,14 +39,14 @@ func mainUsage(f io.Writer) {
 }
 
 var mainHelpTemplate = `
-The modcop command checks that module dependencies do not stray outside
+The modcop command checks that package dependencies do not stray outside
 well defined boundaries. It expects that the set of allowed dependencies
 will be checked in along with the source code, and modcop will be called
 as part of a CI check, so any addition to the set of allowed dependencies
 will need to be explicitly vetted as part of the code review process.
 
 The set of dependencies checked by modcop does not include dependencies
-of test code outside of the module being checked - it differs from
+of test code outside of the packages being checked - it differs from
 the module dependencies calculated by the go command in this respect.
 It also does not consider versions - if it is desired to police allowed
 module versions, a vetted Go proxy could be used.

--- a/testdata/list-external-tests.txt
+++ b/testdata/list-external-tests.txt
@@ -1,0 +1,66 @@
+# check that external test deps are added correctly.
+modcop list -test
+cmp stdout expect-test
+
+modcop list
+cmp stdout expect-no-test
+
+modcop list -testonly
+cmp stdout expect-test-only
+
+# using . should be the same as specifying no args
+modcop list -test .
+cmp stdout expect-test
+
+-- expect-test --
+example.com/a
+fmt
+testing
+-- expect-no-test --
+example.com/a
+fmt
+-- expect-test-only --
+testing
+-- go.mod --
+module m
+
+require (
+	example.com/a v1.0.0
+)
+
+-- main.go --
+package main
+import "example.com/a"
+
+func main() {
+	a.A()
+}
+-- main_test.go --
+package main_test
+import "testing"
+
+func TestMain(t *testing.T) {
+}
+-- .gomodproxy/example.com_a_v1.0.0/.mod --
+module example.com/a
+
+-- .gomodproxy/example.com_a_v1.0.0/.info --
+{"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
+
+-- .gomodproxy/example.com_a_v1.0.0/go.mod --
+module example.com/a
+
+-- .gomodproxy/example.com_a_v1.0.0/a.go --
+package a
+import "fmt"
+
+func A() {
+	fmt.Println("hello, world")
+}
+-- .gomodproxy/example.com_a_v1.0.0/a_test.go --
+package a
+import "testing"
+
+func TestA(t *testing.T) {
+	A()
+}

--- a/testdata/list-internal-tests.txt
+++ b/testdata/list-internal-tests.txt
@@ -1,22 +1,19 @@
-# check that external test deps are added correctly.
 modcop list -test
 cmp stdout expect-test
-
 modcop list
 cmp stdout expect-no-test
-
-# using . should be the same as specifying no args
-modcop list -test .
-cmp stdout expect-test
+modcop list -testonly
+cmp stdout expect-test-only
 
 -- expect-test --
-build example.com/a
-build fmt
-
-test testing
+example.com/a
+fmt
+testing
+-- expect-test-only --
+testing
 -- expect-no-test --
-build example.com/a
-build fmt
+example.com/a
+fmt
 -- go.mod --
 module m
 
@@ -32,7 +29,7 @@ func main() {
 	a.A()
 }
 -- main_test.go --
-package main_test
+package main
 import "testing"
 
 func TestMain(t *testing.T) {

--- a/testdata/list-modules.txt
+++ b/testdata/list-modules.txt
@@ -1,12 +1,22 @@
-modcop list -test
+modcop list -m -test
 cmp stdout expect-test
-modcop list
+modcop list -m
+cmp stdout expect-no-test
+modcop list -m -testonly
+
+# using . should be the same as specifying no args
+modcop list -m -test .
 cmp stdout expect-test
 
 -- expect-test --
-build errors
-build example.com/a
-build fmt
+example.com/a/...
+std
+stdtest
+-- expect-no-test --
+example.com/a/...
+std
+-- expect-testonly --
+stdtest
 -- go.mod --
 module m
 
@@ -21,22 +31,27 @@ import "example.com/a"
 func main() {
 	a.A()
 }
+-- main_test.go --
+package main
+import "testing"
+
+func TestMain(t *testing.T) {
+}
 -- .gomodproxy/example.com_a_v1.0.0/.mod --
 module example.com/a
 
 -- .gomodproxy/example.com_a_v1.0.0/.info --
 {"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
 
+-- .gomodproxy/example.com_a_v1.0.0/go.mod --
+module example.com/a
+
 -- .gomodproxy/example.com_a_v1.0.0/a.go --
 package a
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
-func A() error {
+func A() {
 	fmt.Println("hello, world")
-	return errors.New("e")
 }
 -- .gomodproxy/example.com_a_v1.0.0/a_test.go --
 package a

--- a/testdata/list-no-tests.txt
+++ b/testdata/list-no-tests.txt
@@ -1,16 +1,15 @@
 modcop list -test
 cmp stdout expect-test
 modcop list
-cmp stdout expect-no-test
+cmp stdout expect-test
+modcop list -testonly
+cmp stdout empty
 
 -- expect-test --
-build example.com/a
-build fmt
-
-test testing
--- expect-no-test --
-build example.com/a
-build fmt
+errors
+example.com/a
+fmt
+-- empty --
 -- go.mod --
 module m
 
@@ -25,27 +24,22 @@ import "example.com/a"
 func main() {
 	a.A()
 }
--- main_test.go --
-package main
-import "testing"
-
-func TestMain(t *testing.T) {
-}
 -- .gomodproxy/example.com_a_v1.0.0/.mod --
 module example.com/a
 
 -- .gomodproxy/example.com_a_v1.0.0/.info --
 {"Version":"v1.0.0","Time":"2018-10-22T18:45:39Z"}
 
--- .gomodproxy/example.com_a_v1.0.0/go.mod --
-module example.com/a
-
 -- .gomodproxy/example.com_a_v1.0.0/a.go --
 package a
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
-func A() {
+func A() error {
 	fmt.Println("hello, world")
+	return errors.New("e")
 }
 -- .gomodproxy/example.com_a_v1.0.0/a_test.go --
 package a


### PR DESCRIPTION
This allows `modcop list` to print dependencies at module level,
not just package level.

This branch also adds review changes requested in #5.