### PR TITLE
remove stdtest concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ modcop allow [-m] [packages]
 	
 	The special name "std" can be used to allow all packages
 	in the standard library that don't contain the string "test".
-	The special name "stdtest" can be used to allow all packages
-	in the standard library including test packages.
+	This excludes packages like testing and net/http/httptest,
+	which must be mentioned explicitly.
 
 	If no packages are specified, any dependencies that are
 	used but not mentioned in the go.dep file will be added,
@@ -87,7 +87,7 @@ modcop check [-with file]...
 			golang.org/x/tools/...
 		)
 		test (
-			stdtest
+			testing
 		)
 	
 	Then a call of "modcop check -with /org/go.dep" would fail if the package's

--- a/cmdlist.go
+++ b/cmdlist.go
@@ -55,7 +55,9 @@ func cmdList(_ *Command, args []string) int {
 			var pattern string
 			switch {
 			case p.Standard && strings.Contains(ipName, "test"):
-				pattern = "stdtest"
+				// Test packages in the standard library do not have
+				// a module - they're mentioned explicitly instead.
+				pattern = ipName
 			case p.Standard:
 				pattern = "std"
 			default:

--- a/testdata/list-modules.txt
+++ b/testdata/list-modules.txt
@@ -11,12 +11,12 @@ cmp stdout expect-test
 -- expect-test --
 example.com/a/...
 std
-stdtest
+testing
 -- expect-no-test --
 example.com/a/...
 std
 -- expect-testonly --
-stdtest
+testing
 -- go.mod --
 module m
 


### PR DESCRIPTION
We don't really want to use any package specifiers that
the go command does not support, so remove the `stdtest` concept.
Instead, we treat test packages within the standard library as special - they
are not matched by `std` but instead must be mentioned specifically.

This makes it possible to allow all standard library dependencies with
`std` with the exception of the `testing` package.

In the future, this might be replaced by some more general
exclusion mechanism, but this seems like a reasonable compromise for now.