### PR TITLE
allow replace statements

### DIFF
--- a/testdata/replaced-dep.txt
+++ b/testdata/replaced-dep.txt
@@ -2,8 +2,15 @@
 # We test this by checking that the extra dependency in
 # the replaced package is reflected in the result
 # and that the original dependency's aren't seen there.
-! modcop list
-stderr 'replaced modules not yet supported'
+modcop list -test
+cmp stdout expect
+
+-- expect --
+errors
+fmt
+net/http
+replace.com/a
+testing
 -- go.mod --
 module m
 


### PR DESCRIPTION
Although we don't yet do entirely the right thing, which
would involve running the `go list` command twice,
we can at least explore dependencies in modules with
replacements now.